### PR TITLE
[feat] Add Salesforce colORG to VS Code extensions recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
         "financialforce.lana",
         "mhutchie.git-graph",
         "eamodio.gitlens",
-        "DavidAnson.vscode-markdownlint"
+        "DavidAnson.vscode-markdownlint",
+        "victorgz.vscode-salesforce-colorg"
     ]
 }


### PR DESCRIPTION
This PR adds [Salesforce colORG](https://marketplace.visualstudio.com/items?itemName=victorgz.vscode-salesforce-colorg) extension to recommendations.

This extension allows you to customize VS Code colors depending on the default org alias.
For example, blue for XXX_devX, green for XXX_uatX and red for prod.
